### PR TITLE
Bug Fix: Name sometimes falls under 2nd child not last-child

### DIFF
--- a/src/profile/profileScraperTemplate.js
+++ b/src/profile/profileScraperTemplate.js
@@ -13,7 +13,7 @@ module.exports = {
   profileAlternative: {
     selector: '.pv-content',
     fields: {
-      name: `${alternativeProfileSelector} div:last-child > div:last-child > div:first-child ul:first-child > li:first-child`,
+      name: `${alternativeProfileSelector} div:last-child > div:nth-child(2) > div:first-child ul:first-child > li:first-child`,
       headline: `${alternativeProfileSelector} div:last-child h2`,
       imageurl: {
 		  selector: `${alternativeProfileSelector} div:last-child > div:first-child > div:first-child [src^="https"]`,


### PR DESCRIPTION
Update your profile to:
- Show Business opportunities you provide
- Or open to job opportunities

attempt to scrape your profile or anyone's that shows such data, there is an additional div of class: `pv-top-card-row` which would be the last-child. 
To provide the correct `name` field whethere anyone has such data or not, use the 2nd child