### PR TITLE
Fix: too many sessions open

### DIFF
--- a/src/profile/profile.js
+++ b/src/profile/profile.js
@@ -13,7 +13,7 @@ module.exports = async (browser, cookies, url, waitTimeToScrapMs = 500, hasToGet
 
   const page = await openPage(browser, cookies, url)
   const profilePageIndicatorSelector = '.pv-profile-section'
-  
+
   await page.waitFor(profilePageIndicatorSelector, { timeout: 5000 })
     .catch(() => {
       logger.warn('profile', 'profile selector was not found')
@@ -50,6 +50,7 @@ module.exports = async (browser, cookies, url, waitTimeToScrapMs = 500, hasToGet
   const volunteerExperience = await scrapSection(page, template.volunteerExperience)
   const peopleAlsoViewed = await scrapSection(page, template.peopleAlsoViewed)
 
+  await page.goto("https://www.linkedin.com/m/logout/")
   await page.close()
   logger.info('profile', `finished scraping url: ${url}`)
 

--- a/src/profile/profile.js
+++ b/src/profile/profile.js
@@ -50,7 +50,9 @@ module.exports = async (browser, cookies, url, waitTimeToScrapMs = 500, hasToGet
   const volunteerExperience = await scrapSection(page, template.volunteerExperience)
   const peopleAlsoViewed = await scrapSection(page, template.peopleAlsoViewed)
 
-  await page.goto("https://www.linkedin.com/m/logout/")
+  if(!cookies) {
+    await page.goto("https://www.linkedin.com/m/logout/")
+  }
   await page.close()
   logger.info('profile', `finished scraping url: ${url}`)
 

--- a/src/profile/profileScraperTemplate.js
+++ b/src/profile/profileScraperTemplate.js
@@ -13,7 +13,7 @@ module.exports = {
   profileAlternative: {
     selector: '.pv-content',
     fields: {
-      name: `${alternativeProfileSelector} div:last-child > div:last-child > div:first-child ul:first-child > li:first-child`,
+      name: `${alternativeProfileSelector} div:last-child > div:nth-child(2) > div:first-child ul:first-child > li:first-child`,
       headline: `${alternativeProfileSelector} div:last-child h2`,
       imageurl: {
 		  selector: `${alternativeProfileSelector} div:last-child > div:first-child > div:first-child [src^="https"]`,


### PR DESCRIPTION
Each time you scrape data using the email & password option for auth, you create a new session which is never closed.

Navigate to https://www.linkedin.com/psettings/account to see your active sessions. Max active sessions are 50.
- This `enhancement` logs out from a session when done before closing the page.

Closes: [76](https://github.com/linkedtales/scrapedin/issues/76)

