### PR TITLE
FIX: Node is either not visible or not an HTMLElement for page.click()

### DIFF
--- a/src/profile/scrapAccomplishmentPanel.js
+++ b/src/profile/scrapAccomplishmentPanel.js
@@ -2,21 +2,19 @@ const scrapSection = require('../scrapSection');
 const template = require('./profileScraperTemplate');
 
 const scrapAccomplishmentPanel = async (page, section) => {
-  const openingButton = await page.$(
-    `.pv-accomplishments-block.${section} button`,
-  );
-  
-  if(openingButton) {
-    await openingButton.click();
-    await new Promise((resolve) => {
-      setTimeout(() => {
-        resolve();
-      }, 500);
-    });
+  const queryString = `.pv-accomplishments-block.${section} button`
+
+  const openingButton = await page.$(queryString);
+
+  if (openingButton) {
+    await page.evaluate((q) => {
+      document.querySelector(q).click();
+    }, queryString);
 
     return scrapSection(page, template[section]);
+  } else {
+    return new Promise();
   }
-  
 };
 
 module.exports = scrapAccomplishmentPanel;

--- a/src/profile/scrapAccomplishmentPanel.js
+++ b/src/profile/scrapAccomplishmentPanel.js
@@ -12,8 +12,6 @@ const scrapAccomplishmentPanel = async (page, section) => {
     }, queryString);
 
     return scrapSection(page, template[section]);
-  } else {
-    return new Promise();
   }
 };
 


### PR DESCRIPTION
Fixes #101. 

This is a PR to fix the bug I was getting when the `.pv-accomplishments-block.courses` button was not visible and thus not able to be clicked. It is related to a puppeteer issue: https://github.com/puppeteer/puppeteer/issues/2977. 

The fix was simply to wrap the `.click()` into the `page.evaluate()` function. This also allows the removal of the timeout/wait. 