### PR TITLE
When fetching the recommender, also fetch the img src path.

### DIFF
--- a/src/profile/profileScraperTemplate.js
+++ b/src/profile/profileScraperTemplate.js
@@ -89,6 +89,9 @@ const template = {
       profileImage: {
         selector: 'a img',
         attribute: 'src'
+      },
+      name: {
+        selector: 'a h3'
       }
     }
   },
@@ -103,6 +106,9 @@ const template = {
       profileImage: {
         selector: 'a img',
         attribute: 'src'
+      },
+      name: {
+        selector: 'a h3'
       }
     }
   },
@@ -128,6 +134,9 @@ const template = {
       profileImage: {
         selector: 'a img',
         attribute: 'src'
+      },
+      name: {
+        selector: '.name'
       }
     }
   },

--- a/src/profile/profileScraperTemplate.js
+++ b/src/profile/profileScraperTemplate.js
@@ -92,6 +92,9 @@ const template = {
       },
       name: {
         selector: 'a h3'
+      },
+      userDescription: {
+        selector: '.pv-recommendation-entity__headline'
       }
     }
   },
@@ -109,6 +112,9 @@ const template = {
       },
       name: {
         selector: 'a h3'
+      },
+      userDescription: {
+        selector: '.pv-recommendation-entity__headline'
       }
     }
   },

--- a/src/profile/profileScraperTemplate.js
+++ b/src/profile/profileScraperTemplate.js
@@ -124,7 +124,11 @@ const template = {
         selector: 'a',
         attribute: 'href'
       },
-      text: 'p'
+      text: 'p',
+      profileImage: {
+        selector: 'a img',
+        attribute: 'src'
+      }
     }
   },
   volunteerExperience: {

--- a/src/profile/profileScraperTemplate.js
+++ b/src/profile/profileScraperTemplate.js
@@ -85,7 +85,11 @@ const template = {
         selector: '.pv-recommendation-entity__member',
         attribute: 'href'
       },
-      text: 'blockquote.pv-recommendation-entity__text'
+      text: 'blockquote.pv-recommendation-entity__text',
+      profileImage: {
+        selector: 'a img',
+        attribute: 'src'
+      }
     }
   },
   recommendationsGiven: {
@@ -95,7 +99,11 @@ const template = {
         selector: '.pv-recommendation-entity__member',
         attribute: 'href'
       },
-      text: 'blockquote.pv-recommendation-entity__text'
+      text: 'blockquote.pv-recommendation-entity__text',
+      profileImage: {
+        selector: 'a img',
+        attribute: 'src'
+      }
     }
   },
   accomplishments: {


### PR DESCRIPTION
Some times the base64 is coming back instead of a path whenever there is no photo.
I think it's ok to return that as well.